### PR TITLE
Fix unqualified keycap sequence misclassification

### DIFF
--- a/emoji_presentation_scanner.c
+++ b/emoji_presentation_scanner.c
@@ -163,7 +163,7 @@ _eof_trans:
 	break;
 	case 13:
 #line 102 "emoji_presentation_scanner.rl"
-	{te = p+1;{ *is_emoji = true;  *has_vs = false; return te; }}
+	{te = p+1;{ *is_emoji = false;  *has_vs = false; return te; }}
 	break;
 	case 8:
 #line 103 "emoji_presentation_scanner.rl"

--- a/emoji_presentation_scanner.rl
+++ b/emoji_presentation_scanner.rl
@@ -99,7 +99,7 @@ text_and_emoji_run := |*
 text_emoji_run_with_vs => { *is_emoji = false; *has_vs = true; return te; };
 emoji_run_with_vs => { *is_emoji = true; *has_vs = true; return te; };
 emoji_run => { *is_emoji = true; *has_vs = false; return te; };
-unqualified_keycap_sequence => { *is_emoji = true;  *has_vs = false; return te; };
+unqualified_keycap_sequence => { *is_emoji = false;  *has_vs = false; return te; };
 text_run => { *is_emoji = false; *has_vs = false; return te; };
 *|;
 

--- a/emoji_test_data.h
+++ b/emoji_test_data.h
@@ -73,7 +73,7 @@
     COMBINING_ENCLOSING_KEYCAP
   },
   .length = 2,
-  .is_emoji = true,
+  .is_emoji = false,
   .has_vs = false
 },
 {

--- a/emoji_test_data.py
+++ b/emoji_test_data.py
@@ -37,7 +37,7 @@ def get_emoji_segmentation_category(cp):
         return "EMOJI_EMOJI_PRESENTATION"
     if regex.match(r"[[\p{Emoji}]&&[\P{Emoji_Presentation}]]", c):
         return "EMOJI_TEXT_PRESENTATION"
-    return "0x0000"
+    return "0xFF"
 
 
 TestUnitRx = regex.compile(

--- a/emoji_test_data.py
+++ b/emoji_test_data.py
@@ -97,7 +97,7 @@ DATA = """
 0031;false;false;Lone keycap base
 0031 FE0E;false;true;Keycap base + VS-15 (no term)
 0031 FE0F;true;true;Keycap base + VS-16 (no term)
-0023 20E3;true;false;Unqualified keycap
+0023 20E3;false;false;Unqualified keycap
 0031 FE0E 20E3;false;true;Keycap + VS-15 + term
 002A FE0F 20E3;true;true;Qualified keycap
 


### PR DESCRIPTION
- `emoji_presentation_scanner.rl`: unqualified keycap sequence (`KEYCAP_BASE` + `CEK`,
  no VS-16) is a legacy compatibility sequence and should be `is_emoji=false`,
  consistent with a VS-15 keycap
- `emoji_presentation_scanner.c`: regenerated from updated grammar
- `emoji_test_data.h`: regenerated to reflect corrected `is_emoji=false`
- `emoji_test_data.py`: fix fallback category from `0x0000` (collides with `EMOJI`) to `0xFF`